### PR TITLE
Add Line Chart To Stats

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,10 @@ class User < ApplicationRecord
     user_moods.joins(:mood).select(:name).group(:name).count
   end
 
+  def mood_over_time
+    user_moods.joins(:mood).group_by_day(:created_at).sum(:rating)
+  end
+
   def suggested_videos
     rating = mood_rating
     if rating < 1.5

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,3 +1,18 @@
-<h1>Stats</h1>
+<section class='container'>
+  <section class='row'>
+    <div class="col-md-6 justify-content-start">
+      <h1>Stats</h1>
 
-<%= pie_chart current_user.mood_query %>
+      <%= link_to "Pie Chart", stats_path(chart: :pie) %> | <%= link_to "Line Chart", stats_path(chart: :line) %>
+      <br /><br />
+      <% if params[:chart] == "pie" %>
+        <%= pie_chart current_user.mood_query %>
+      <% end %>
+
+      <% if params[:chart] == "line" %>
+        <%= line_chart current_user.mood_over_time,
+          label: "Mood Rating", xtitle: "Date", ytitle: "Mood", width: "600px" %>
+      <% end %>
+    </div>
+  </section>
+</section>

--- a/spec/features/user/view_stats_spec.rb
+++ b/spec/features/user/view_stats_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'As a user' do
     mood1 = Mood.create(name: 'worried', rating: 1)
     mood2 = Mood.create(name: 'neutral_face', rating: 2)
     mood3 = Mood.create(name: 'smile', rating: 3)
-    
+
     mood_entry1 = UserMood.create(user_id: user.id, mood_id: mood1.id, created_at: 'Tue 26 May 2020 21:21:12 UTC +00:00', updated_at: 'Tue 26 May 2020 21:21:12 UTC +00:00')
     mood_entry2 = UserMood.create(user_id: user.id, mood_id: mood2.id, created_at: 'Wed 27 May 2020 21:21:12 UTC +00:00', updated_at: 'Wed 27 May 2020 21:21:12 UTC +00:00')
     mood_entry3 = UserMood.create(user_id: user.id, mood_id: mood3.id, created_at: 'Thu 28 May 2020 21:21:12 UTC +00:00', updated_at: 'Thu 28 May 2020 21:21:12 UTC +00:00')
@@ -21,5 +21,7 @@ RSpec.describe 'As a user' do
     expect(current_path).to eq('/dashboard')
     find(:xpath, "//a[@href='/stats']").click
     assert_css('.chartjs-render-monitor') if has_css?('.chartjs-render-monitor', visible: :all)
+    expect(page).to have_link "Pie Chart"
+    expect(page).to have_link "Line Chart"
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe User, type: :model do
       mood_entry5 = UserMood.create(user_id: user.id, mood_id: mood3.id, created_at: 'Sat 30 May 2020 21:21:12 UTC +00:00', updated_at: 'Sat 30 May 2020 21:21:12 UTC +00:00')
       expect(user.mood_query).to eq({"neutral_face"=>1, "smile"=>3, "worried"=>1})
     end
+    it '.mood_over_time' do
+      user = create(:user)
+      mood1 = Mood.create(name: 'worried', rating: 1)
+      mood2 = Mood.create(name: 'neutral_face', rating: 2)
+      mood3 = Mood.create(name: 'smile', rating: 3)
+      mood_entry1 = UserMood.create(user_id: user.id, mood_id: mood1.id, created_at: 'Tue 26 May 2020 21:21:12 UTC +00:00', updated_at: 'Tue 26 May 2020 21:21:12 UTC +00:00')
+      mood_entry2 = UserMood.create(user_id: user.id, mood_id: mood2.id, created_at: 'Wed 27 May 2020 21:21:12 UTC +00:00', updated_at: 'Wed 27 May 2020 21:21:12 UTC +00:00')
+      mood_entry3 = UserMood.create(user_id: user.id, mood_id: mood3.id, created_at: 'Thu 28 May 2020 21:21:12 UTC +00:00', updated_at: 'Thu 28 May 2020 21:21:12 UTC +00:00')
+      expect(user.mood_over_time).to eq({'Tue 26 May 2020'.to_date  =>1, 'Wed, 27 May 2020'.to_date =>2, 'Thu, 28 May 2020'.to_date =>3})
+    end
   end
 
   describe 'instance methods' do


### PR DESCRIPTION
## What functionality does this accomplish?
- Add Line Chart to Stats 
- Add User method mood_over_time
adds to #6 
**Description:**
User can now see a line chart on the stats page

## Current Test Suite: RSpec
### Test Coverage Percentage: 100.0%
- [ ] No tests have been changed
- [x] Some tests have been changed (Added links to the view so checking for that)
- [ ] All of the tests have been changed(Please describe what in the world happened):
### Rubocop:
- [x] No offenses
- [ ] Offenses (number of offenses: _ )
## Checklist:
- [ ] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [ ] I have partially tested my code (please explain why):
## Helpful Resources:
-
